### PR TITLE
added 404 resource not found

### DIFF
--- a/src/gateway/accounts/apiproxy/policies/Raise-Fault-Resource-Not-Found.xml
+++ b/src/gateway/accounts/apiproxy/policies/Raise-Fault-Resource-Not-Found.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+ Copyright 2017 Google Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limit
+-->
+<RaiseFault async="false" continueOnError="false" enabled="true" name="Raise-Fault-Resource-Not-Found">
+    <DisplayName>Error: Raise Fault Resource Not Found</DisplayName>
+    <Properties/>
+    <FaultResponse>
+        <Set>
+            <Headers/>
+            <Payload contentType="application/json" variablePrefix="@" variableSuffix="#">
+        
+            {
+            "ErrorResponseCode" : "resource_not_found",
+            "ErrorDescription" : "Resource not found"
+            }
+        
+    </Payload>
+            <StatusCode>404</StatusCode>
+            <ReasonPhrase>Resource Not Found</ReasonPhrase>
+        </Set>
+    </FaultResponse>
+    <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+</RaiseFault>

--- a/src/gateway/accounts/apiproxy/proxies/default.xml
+++ b/src/gateway/accounts/apiproxy/proxies/default.xml
@@ -335,14 +335,12 @@
             </Response>
             <Condition>((proxy.pathsuffix MatchesPath "/accounts") or (proxy.pathsuffix MatchesPath "/accounts/{AccountId}") ) and (request.verb = "GET")</Condition>
         </Flow>
-        <Flow name="InvalidPath">
-            <Description/>
+        <Flow name="Resource not found">
             <Request>
                 <Step>
-                    <Name>Raise-Fault-Invalid-Operation</Name>
+                    <Name>Raise-Fault-Resource-Not-Found</Name>
                 </Step>
             </Request>
-            <Response/>
         </Flow>
     </Flows>
     <HTTPProxyConnection>

--- a/src/gateway/oauth/apiproxy/policies/Raise-Fault-Resource-Not-Found.xml
+++ b/src/gateway/oauth/apiproxy/policies/Raise-Fault-Resource-Not-Found.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+ Copyright 2017 Google Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limit
+-->
+<RaiseFault async="false" continueOnError="false" enabled="true" name="Raise-Fault-Resource-Not-Found">
+    <DisplayName>Error: Raise Fault Resource Not Found</DisplayName>
+    <Properties/>
+    <FaultResponse>
+        <Set>
+            <Headers/>
+            <Payload contentType="application/json" variablePrefix="@" variableSuffix="#">
+        
+            {
+            "ErrorResponseCode" : "resource_not_found",
+            "ErrorDescription" : "Resource not found"
+            }
+        
+    </Payload>
+            <StatusCode>404</StatusCode>
+            <ReasonPhrase>Resource Not Found</ReasonPhrase>
+        </Set>
+    </FaultResponse>
+    <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+</RaiseFault>

--- a/src/gateway/oauth/apiproxy/proxies/default.xml
+++ b/src/gateway/oauth/apiproxy/proxies/default.xml
@@ -196,6 +196,13 @@
             </Response>
             <Condition>(proxy.pathsuffix MatchesPath "/authorized") and (request.verb = "POST")</Condition>
         </Flow>
+        <Flow name="Resource not found">
+            <Request>
+                <Step>
+                    <Name>Raise-Fault-Resource-Not-Found</Name>
+                </Step>
+            </Request>
+        </Flow>
     </Flows>
     <HTTPProxyConnection>
         <BasePath>/apis/v1.0/oauth</BasePath>

--- a/src/gateway/payments/apiproxy/policies/Raise-Fault-Resource-Not-Found.xml
+++ b/src/gateway/payments/apiproxy/policies/Raise-Fault-Resource-Not-Found.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+ Copyright 2017 Google Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limit
+-->
+<RaiseFault async="false" continueOnError="false" enabled="true" name="Raise-Fault-Resource-Not-Found">
+    <DisplayName>Error: Raise Fault Resource Not Found</DisplayName>
+    <Properties/>
+    <FaultResponse>
+        <Set>
+            <Headers/>
+            <Payload contentType="application/json" variablePrefix="@" variableSuffix="#">
+        
+            {
+            "ErrorResponseCode" : "resource_not_found",
+            "ErrorDescription" : "Resource not found"
+            }
+        
+    </Payload>
+            <StatusCode>404</StatusCode>
+            <ReasonPhrase>Resource Not Found</ReasonPhrase>
+        </Set>
+    </FaultResponse>
+    <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+</RaiseFault>

--- a/src/gateway/payments/apiproxy/proxies/default.xml
+++ b/src/gateway/payments/apiproxy/proxies/default.xml
@@ -192,6 +192,13 @@
             <Response/>
             <Condition>(proxy.pathsuffix MatchesPath "/payment-submissions/*") and (request.verb = "GET")</Condition>
         </Flow>
+        <Flow name="Resource not found">
+            <Request>
+                <Step>
+                    <Name>Raise-Fault-Resource-Not-Found</Name>
+                </Step>
+            </Request>
+        </Flow>
     </Flows>
     <HTTPProxyConnection>
         <BasePath>/pis/open-banking/v1.0</BasePath>

--- a/src/gateway/sms-token/apiproxy/policies/Raise-Fault-Resource-Not-Found.xml
+++ b/src/gateway/sms-token/apiproxy/policies/Raise-Fault-Resource-Not-Found.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+ Copyright 2017 Google Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limit
+-->
+<RaiseFault async="false" continueOnError="false" enabled="true" name="Raise-Fault-Resource-Not-Found">
+    <DisplayName>Error: Raise Fault Resource Not Found</DisplayName>
+    <Properties/>
+    <FaultResponse>
+        <Set>
+            <Headers/>
+            <Payload contentType="application/json" variablePrefix="@" variableSuffix="#">
+        
+            {
+            "ErrorResponseCode" : "resource_not_found",
+            "ErrorDescription" : "Resource not found"
+            }
+        
+    </Payload>
+            <StatusCode>404</StatusCode>
+            <ReasonPhrase>Resource Not Found</ReasonPhrase>
+        </Set>
+    </FaultResponse>
+    <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+</RaiseFault>

--- a/src/gateway/sms-token/apiproxy/proxies/default.xml
+++ b/src/gateway/sms-token/apiproxy/proxies/default.xml
@@ -85,6 +85,13 @@
             </Response>
             <Condition>(proxy.pathsuffix MatchesPath "/confirmation/{identifier}") and (request.verb = "POST")</Condition>
         </Flow>
+        <Flow name="Resource not found"> 
+            <Request>
+                <Step>
+                    <Name>Raise-Fault-Resource-Not-Found</Name>
+                </Step>
+            </Request>
+        </Flow>
     </Flows>
     <HTTPProxyConnection>
         <BasePath>/internal/apis/v1.0/sms</BasePath>

--- a/test/features/404.feature
+++ b/test/features/404.feature
@@ -1,0 +1,21 @@
+Feature: 
+    As an API Consumer
+    I want to receive an error when requesting an unknown resource
+    So that I can debug my application
+    
+    Scenario: Fail to request an unknown resource in the accounts proxy
+        Given TPP obtains the oauth accesstoken-client credentials with accounts scope and store in global scope
+        And I set Authorization header to Bearer `accesstoken_cc`
+        When I GET /ais/open-banking/v1.0/unknown
+        Then response code should be 404
+        And response body should be valid json
+        And response body path ErrorResponseCode should be resource_not_found
+        And response body path ErrorDescription should be Resource not found
+
+    Scenario: Fail to request an unknown resource in the oauth proxy
+        When I GET /apis/v1.0/oauth/unknown
+        Then response code should be 404
+        And response body should be valid json
+        And response body path ErrorResponseCode should be resource_not_found
+        And response body path ErrorDescription should be Resource not found
+

--- a/test/features/accounts.feature
+++ b/test/features/accounts.feature
@@ -74,7 +74,7 @@ Feature:
       | /ais/open-banking/v1.0/accounts/987654321/standing-orders |
       | /ais/open-banking/v1.0/accounts/987654321/direct-debits   |
       | /ais/open-banking/v1.0/accounts/987654321/product         |
-
+  
   Scenario Outline: TPP makes GET Accounts API call with missing x-fapi-financial-id header
     Given TPP sets the request headers
       | name                       | value                |
@@ -92,7 +92,7 @@ Feature:
       | /ais/open-banking/v1.0/beneficiaries                      |
       | /ais/open-banking/v1.0/standing-orders                    |
       | /ais/open-banking/v1.0/direct-debits                      |
-      | /ais/open-banking/v1.0/accounts/987654321/                |
+      | /ais/open-banking/v1.0/accounts/987654321                 |
       | /ais/open-banking/v1.0/accounts/987654321/balances        |
       | /ais/open-banking/v1.0/accounts/987654321/transactions    |
       | /ais/open-banking/v1.0/accounts/987654321/beneficiaries   |


### PR DESCRIPTION
Added tests and implementation for generic 404 Resource Not Found

Please note: tests for Payment API 404 will created along with the rest of the Payment API tests.