### PR TITLE
Resolved error response for missing redirectUri error

### DIFF
--- a/src/gateway/login-app/apiproxy/resources/node/controllers/login.js
+++ b/src/gateway/login-app/apiproxy/resources/node/controllers/login.js
@@ -47,7 +47,7 @@ login.loginForm = function (req, res, next) {
                 stack: redirectUri
             }
         }
-        res.render(error, err);
+        res.render('error', err);
     } else if (!state) {
         console.log("Invalid State value");
         var err = config.errors.invalid_state;


### PR DESCRIPTION
Application threw 'error undefined' when no redirect-uri is passed in params. In render function, error object was passed (which was undefined), instead of 'error'.